### PR TITLE
internal: app: fix: Update handler template to include package declaration

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -207,7 +207,7 @@ func (p *Project) CreateInternalDir() {
 		Must(
 			template.
 				New("handlers.go").
-				Parse(tmpl.HandlerTmpl(p.FrameWork))).
+				Parse("package handlers\n\n"+tmpl.HandlerTmpl(p.FrameWork))).
 		Execute(handlersFile, p)
 	if err != nil {
 		errChan <- err


### PR DESCRIPTION
"git fmt ./..." kept failing due to - internal/handlers/handlers.go:1:1: expected "package", found "EOF"