### PR TITLE
add: README templating and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,20 +96,23 @@ This project is licensed under the [MIT License](LICENSE).
 
 Contributions are welcome! Please follow these steps:
 
-1. Fork the repository.
-2. Create a new branch:
+1. Fork the repository. Clone the repository.
+2. Create a new branch and install dependencies:
    ```bash
    git checkout -b feature/your-feature
+   go mod tidy
    ```
-3. Commit your changes:
+3. Format using `gofmt` to ensure it adheres to Go style guidelines.
+
+4. Commit your changes with clear commit message:
    ```bash
    git commit -m "Add your feature"
    ```
-4. Push the branch:
+5. Push the branch:
    ```bash
    git push origin feature/your-feature
    ```
-5. Open a pull request.
+6. Open a pull request.
 
 ## 💪 Support
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,6 +49,12 @@ var initCmd = &cobra.Command{
 			),
 			huh.NewGroup(
 				huh.NewInput().
+					Value(&p.Description).
+					Title("Description").
+					Description("Enter a description"),
+			),
+			huh.NewGroup(
+				huh.NewInput().
 					Value(&p.ModName).
 					Title("Module Name").
 					Description("Enter a name of the module\nPress <Enter> to use the same as project name").

--- a/internal/app.d.go
+++ b/internal/app.d.go
@@ -3,10 +3,11 @@ package app
 import "fmt"
 
 type Project struct {
-	Name      string
-	ModName   string
-	FrameWork string
-	Database  string
+	Name        string
+	Description string
+	ModName     string
+	FrameWork   string
+	Database    string
 }
 
 type AppError struct {

--- a/internal/app.go
+++ b/internal/app.go
@@ -37,7 +37,16 @@ func (p *Project) ScaffoldProject() error {
 	if err != nil {
 		return err
 	}
+
 	defer f.Close()
+
+	err = template.
+		Must(
+			template.New("README.md").Parse(tmpl.ReadmeMdTmpl)).
+		Execute(f, p)
+	if err != nil {
+		errChan <- err
+	}
 
 	// Creates .env file
 	f, err = os.Create(".env")

--- a/internal/templates/files/readme.md.tmpl
+++ b/internal/templates/files/readme.md.tmpl
@@ -1,0 +1,11 @@
+# {{ .Name }}
+
+{{ .Description }}
+
+## Getting Started
+
+To run the project, use:
+
+``` bash
+go run main.go
+```

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -11,6 +11,8 @@ var (
 	ServerTmpl string
 	//go:embed files/env.tmpl
 	EnvTmpl string
+	//go:embed files/readme.md.tmpl
+	ReadmeMdTmpl string
 
 	// Database Templates
 	//go:embed database/mongo.go.tmpl

--- a/main.go
+++ b/main.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
 */
 package main
 


### PR DESCRIPTION
# Describe the feature

This PR adds support for project description.

The description along with project name gets written to README.md, similar to GitHub's default initialization with a getting started section.

Nearly every project scaffolding utility covers description: Poetry, npm, etc. and thought this would be a good addition.

In the future, making it compliant with pkg.go.dev would be a good consideration by adding support for license, author and other fields and I will be working on that.

# Checklist
- [x] I have formatted my source code
- [x] I have tested it on my system