### PR TITLE
Fix/build error printing

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,7 +24,7 @@ var buildCmd = &cobra.Command{
 			New().
 			Title("Building").
 			Action(func() {
-				_, err := exec.Command("go", "build").Output()
+				_, err = exec.Command("go", "build").CombinedOutput()
 				if err != nil {
 					flag = false
 				}
@@ -39,7 +39,7 @@ var buildCmd = &cobra.Command{
 				Render(fmt.Sprintf("%s Built vgo", asset.EmojiTick)))
 		} else {
 			cmd.Println(asset.Text.Foreground(asset.Red).
-				Render(fmt.Sprintf("%s Error : Failed to build the vgo tool\n%s", asset.EmojiError, err)))
+				Render(fmt.Sprintf("%s Error : Failed to build the vgo tool\n%v", asset.EmojiError, err)))
 			return
 		}
 
@@ -47,7 +47,7 @@ var buildCmd = &cobra.Command{
 			New().
 			Title("Installing").
 			Action(func() {
-				_, err := exec.Command("go", "install").Output()
+				_, err = exec.Command("go", "install").CombinedOutput()
 				if err != nil {
 					flag = false
 				}
@@ -61,7 +61,7 @@ var buildCmd = &cobra.Command{
 				Render(fmt.Sprintf("%s Installed vgo", asset.EmojiTick)))
 		} else {
 			cmd.Println(asset.Text.Foreground(asset.Red).
-				Render(fmt.Sprintf("%s Error : Failed to update the vgo tool\n%s", asset.EmojiError, err)))
+				Render(fmt.Sprintf("%s Error : Failed to update the vgo tool\n%v", asset.EmojiError, err)))
 			return
 		}
 	},

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,14 +17,18 @@ var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the vgo tool and install it",
 	Run: func(cmd *cobra.Command, args []string) {
-		var err error
-		flag := true
+		var (
+			err        error
+			flag       = true
+			buildOut   []byte
+			installOut []byte
+		)
 
 		_ = spinner.
 			New().
 			Title("Building").
 			Action(func() {
-				_, err = exec.Command("go", "build").CombinedOutput()
+				buildOut, err = exec.Command("go", "build").CombinedOutput()
 				if err != nil {
 					flag = false
 				}
@@ -39,7 +43,7 @@ var buildCmd = &cobra.Command{
 				Render(fmt.Sprintf("%s Built vgo", asset.EmojiTick)))
 		} else {
 			cmd.Println(asset.Text.Foreground(asset.Red).
-				Render(fmt.Sprintf("%s Error : Failed to build the vgo tool\n%v", asset.EmojiError, err)))
+				Render(fmt.Sprintf("%s Error : Failed to build the vgo tool\n%v\n%s", asset.EmojiError, err, string(buildOut))))
 			return
 		}
 
@@ -47,7 +51,7 @@ var buildCmd = &cobra.Command{
 			New().
 			Title("Installing").
 			Action(func() {
-				_, err = exec.Command("go", "install").CombinedOutput()
+				installOut, err = exec.Command("go", "install").CombinedOutput()
 				if err != nil {
 					flag = false
 				}
@@ -61,7 +65,7 @@ var buildCmd = &cobra.Command{
 				Render(fmt.Sprintf("%s Installed vgo", asset.EmojiTick)))
 		} else {
 			cmd.Println(asset.Text.Foreground(asset.Red).
-				Render(fmt.Sprintf("%s Error : Failed to update the vgo tool\n%v", asset.EmojiError, err)))
+				Render(fmt.Sprintf("%s Error : Failed to update the vgo tool\n%v\n%s", asset.EmojiError, err, string(installOut))))
 			return
 		}
 	},


### PR DESCRIPTION
- Fix incorrect error message in vgo build/install (previously showed “%!s(<nil>)” and hid real failure)
- Root cause: err was shadowed inside spinner actions; error formatted with %s; stderr lost by using Output()
- Changes: assign to outer err; use CombinedOutput to capture stderr/stdout; print with %v; include command output in failure paths
- Result: failures (e.g., running outside a Go module) now surface Go’s actual error; success path unchanged; go build/vet pass