### PR TITLE
feat: better screen reader compatibility for a11y and DX by .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Build files
+build/
+vgo

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 Vgo is a simple go project scaffolding tool with user-friendly command-line interface written in Go. This tool saves time, ensures consistent project structure, and improves development efficiency.
 
 > **NOTE** : This is my first open source contribution. I hope this tool will be useful to many developers and help them in their projects. I am open to feedback and suggestions to improve this tool further.
-This is the first version of the tool and I will be adding more features and improvements in the future.
+> This is the first version of the tool and I will be adding more features and improvements in the future.
 
 ## 🚀 Demo
+
 ![Demo](./demo.gif)
 
 See it is that simple to create a new project with vgo. Just run the command `vgo init` and answer the questions to create a new project.
@@ -31,6 +32,7 @@ This is the list of features that I am planning to add in the future. I will be 
 ## ⬇️ Installation
 
 ### Prerequisites
+
 - [Go](https://golang.org/dl/) (Version 1.23.3 or higher is recommended)
 
 ### 1. Using `go install`
@@ -42,20 +44,22 @@ go install github.com/vg006/vgo@latest
 ### 2. Building from Source
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/vg006/vgo.git
    cd vgo
    ```
 
 2. Build the binary:
+
    ```bash
-   go build -o vgo
+   go build
    ```
 
 3. Install the binary to your Go bin directory:
    ```bash
     go install
-    ```
+   ```
    (or)
    Add the binary to your PATH:
    ```bash
@@ -74,19 +78,17 @@ go install github.com/vg006/vgo@latest
    ```
 3. **To Build and Install the binary**:
    > **NOTE**: This command is only for development purposes.
-   It builds the binary file of the tool and install it.
+   > It builds the binary file of the tool and install it.
    ```bash
    vgo build
    ```
 
-
 ### Available Flags
 
-| Flag            | Description                                         |
-|-----------------|-----------------------------------------------------|
-| `--help`        | Display help information.                           |
-
-
+| Flag           | Short Flag | Description                                        |
+| -------------- | ---------- | -------------------------------------------------- |
+| `--help`       | `-h`       | Display help information.                          |
+| `--accessible` | `-a`       | Set accessibility for screen reader compatibility. |
 
 ## 📄 License
 
@@ -103,7 +105,9 @@ Contributions are welcome! Please follow these steps:
    go mod tidy
    ```
 3. Format using `gofmt` to ensure it adheres to Go style guidelines.
-
+   ``` bash
+   gofmt -w .
+   ```
 4. Commit your changes with clear commit message:
    ```bash
    git commit -m "Add your feature"
@@ -121,7 +125,8 @@ If you encounter any issues or have questions, feel free to open an issue on [Gi
 ## 🙏 Acknowledgments
 
 Special thanks to,
+
 - the Go community, for their invaluable resources and inspiration.
 - [MelkeyDev](https://github.com/MelkeyDev), for the inspiration to build this tool.
 - [Cobra CLI](https://github.com/spf13/cobra), for helping to build command-line interface.
-- [Charm_](https://github.com/charmbracelet), for building beautiful and interactive CLI components.
+- [Charm\_](https://github.com/charmbracelet), for building beautiful and interactive CLI components.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,14 +9,11 @@ import (
 	asset "github.com/vg006/vgo/internal/assets"
 )
 
-func init() {
-	rootCmd.AddCommand(buildCmd)
-}
-
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the vgo tool and install it",
 	Run: func(cmd *cobra.Command, args []string) {
+		accessible, _ := cmd.Flags().GetBool("accessible")
 		var (
 			err        error
 			flag       = true
@@ -35,7 +32,7 @@ var buildCmd = &cobra.Command{
 
 			}).
 			Style(asset.Text).
-			Accessible(false).
+			Accessible(accessible).
 			Run()
 
 		if flag {
@@ -57,7 +54,7 @@ var buildCmd = &cobra.Command{
 				}
 			}).
 			Style(asset.Text).
-			Accessible(false).
+			Accessible(accessible).
 			Run()
 
 		if flag {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -12,16 +12,12 @@ import (
 	asset "github.com/vg006/vgo/internal/assets"
 )
 
-func init() {
-	rootCmd.AddCommand(initCmd)
-}
-
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new Go project",
 	Run: func(cmd *cobra.Command, args []string) {
 		var p app.Project
-
+		accessible, _ := cmd.Flags().GetBool("accessible")
 		form := huh.NewForm(
 			huh.NewGroup(
 				huh.NewInput().
@@ -92,7 +88,7 @@ var initCmd = &cobra.Command{
 					),
 			),
 		).
-			WithAccessible(false).
+			WithAccessible(accessible).
 			WithTheme(asset.SetTheme())
 
 		fmt.Println(asset.VgoLogo)
@@ -126,7 +122,7 @@ var initCmd = &cobra.Command{
 				}
 			}).
 			Style(asset.Text).
-			Accessible(false).
+			Accessible(accessible).
 			Run()
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,8 +19,9 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-// --- Executes the command ---
 func Execute() {
+	rootCmd.AddCommand(initCmd, updateCmd, buildCmd)
+	rootCmd.PersistentFlags().BoolP("accessible", "a", false, "Set accessibility for screen reader compatibility")
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -9,14 +9,11 @@ import (
 	asset "github.com/vg006/vgo/internal/assets"
 )
 
-func init() {
-	rootCmd.AddCommand(updateCmd)
-}
-
 var updateCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Update the vgo tool to the latest version",
 	Run: func(cmd *cobra.Command, args []string) {
+		accessible, _ := cmd.Flags().GetBool("accessible")
 		_ = spinner.
 			New().
 			Title("Updating vgo ...").
@@ -32,7 +29,7 @@ var updateCmd = &cobra.Command{
 						Render(fmt.Sprintf("%s Yupee! You are now up-to-date!", asset.EmojiSparkles)))
 			}).
 			Style(asset.Text).
-			Accessible(false).
+			Accessible(accessible).
 			Run()
 	},
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -32,7 +32,8 @@ func (p *Project) ScaffoldProject() error {
 	if err != nil {
 		return err
 	}
-	// Creates a Readme.md File
+
+	// Creates README.md
 	f, err := os.Create("README.md")
 	if err != nil {
 		return err
@@ -54,7 +55,7 @@ func (p *Project) ScaffoldProject() error {
 		return err
 	}
 	defer f.Close()
-	// Writes into the .env file
+	// Writes into .env
 	err = template.
 		Must(
 			template.
@@ -62,7 +63,24 @@ func (p *Project) ScaffoldProject() error {
 				Parse(tmpl.EnvTmpl)).
 		Execute(f, p)
 	if err != nil {
+		errChan <- err
+	}
+
+	// Creates .gitignore file
+	f, err = os.Create(".gitignore")
+	if err != nil {
 		return err
+	}
+	defer f.Close()
+	// Writes into .gitignore file
+	err = template.
+		Must(
+			template.
+				New(".gitignore").
+				Parse(tmpl.GitignoreTmpl)).
+		Execute(f, p)
+	if err != nil {
+		errChan <- err
 	}
 
 	// Creates other project directories

--- a/internal/templates/files/gitignore.tmpl
+++ b/internal/templates/files/gitignore.tmpl
@@ -1,0 +1,6 @@
+# Build files
+build
+{{ .Name }}
+
+# Environment variable files
+.env*

--- a/internal/templates/template.go
+++ b/internal/templates/template.go
@@ -13,6 +13,8 @@ var (
 	EnvTmpl string
 	//go:embed files/readme.md.tmpl
 	ReadmeMdTmpl string
+	//go:embed files/gitignore.tmpl
+	GitignoreTmpl string
 
 	// Database Templates
 	//go:embed database/mongo.go.tmpl


### PR DESCRIPTION
# Description
This PR integrates:
- Support for accessibility with screen readers by a persistent accessibility flag in the root command, which was previously having accessibility issues with screen readers due to persistent rendering. This can be used by `--accessible` or `-a` flag.
- .gitignore file template to ignore build files and .env files which reduces another boilerplate for developers, thus enhancing DX.

# Tests
- [x] I have tested these changes locally on my system